### PR TITLE
fix: add --no-stdin to prevent unintended input warning

### DIFF
--- a/lua/marp.lua
+++ b/lua/marp.lua
@@ -318,7 +318,7 @@ function M.export(format)
 
   local marp_cmd = get_marp_cmd()
   local output_file = file:gsub("%.md$", "")
-  local cmd = string.format("%s %s '%s'", marp_cmd, export_flag, file)
+  local cmd = string.format("%s --no-stdin %s '%s'", marp_cmd, export_flag, file)
 
   -- Determine output filename
   local ext_map = {


### PR DESCRIPTION
### Summary

This pull request fixes an issue where the :MarpExport command fails to generate a file and instead displays an error message.

### Changes

- Explicitly adds the `--no-stdin` option when invoking Marp CLI

### Context

When running the :MarpExport pdf command, the following error message is shown and the PDF file is not generated:

```
[Export stderr] finished reading. (Pass --no-stdin option if it was not intended)
```

This error occurs because Marp CLI unintentionally attempts to read from standard input.
By adding the --no-stdin option, we can prevent this error and ensure the file is generated correctly.

Let me know if any further adjustments are needed!